### PR TITLE
DccCert Trimmed Strings

### DIFF
--- a/src/main/java/ch/admin/bag/covidcertificate/sdk/core/data/moshi/TrimmedStringAdapter.kt
+++ b/src/main/java/ch/admin/bag/covidcertificate/sdk/core/data/moshi/TrimmedStringAdapter.kt
@@ -1,0 +1,24 @@
+package ch.admin.bag.covidcertificate.sdk.core.data.moshi
+
+import com.squareup.moshi.JsonAdapter
+import com.squareup.moshi.JsonReader
+import com.squareup.moshi.JsonWriter
+
+/**
+ * A Moshi json adapter that parses JSON into trimmed strings
+ */
+class TrimmedStringAdapter : JsonAdapter<String>() {
+	override fun fromJson(reader: JsonReader): String? {
+		if (reader.peek() == JsonReader.Token.NULL) {
+			return reader.nextNull<String>()
+		}
+		return reader.nextString().trim()
+	}
+
+	override fun toJson(writer: JsonWriter, value: String?) {
+		value?.let {
+			writer.value(it)
+		} ?: writer.nullValue()
+	}
+
+}

--- a/src/main/java/ch/admin/bag/covidcertificate/sdk/core/decoder/chain/CborService.kt
+++ b/src/main/java/ch/admin/bag/covidcertificate/sdk/core/decoder/chain/CborService.kt
@@ -13,6 +13,7 @@
  */
 package ch.admin.bag.covidcertificate.sdk.core.decoder.chain
 
+import ch.admin.bag.covidcertificate.sdk.core.data.moshi.TrimmedStringAdapter
 import ch.admin.bag.covidcertificate.sdk.core.models.healthcert.CertificateHolder
 import ch.admin.bag.covidcertificate.sdk.core.models.healthcert.eu.DccCert
 import ch.admin.bag.covidcertificate.sdk.core.models.healthcert.light.ChLightCert
@@ -30,7 +31,10 @@ internal object CborService {
 	// Takes qrCodeData to directly construct a Bagdgc AND keep the field in the DCC a val
 	fun decode(input: ByteArray, qrCodeData: String): CertificateHolder? {
 
-		val moshi = Moshi.Builder().add(Date::class.java, Rfc3339DateJsonAdapter()).build()
+		val moshi = Moshi.Builder()
+			.add(Date::class.java, Rfc3339DateJsonAdapter())
+			.add(String::class.java, TrimmedStringAdapter())
+			.build()
 		val dccCertAdapter = moshi.adapter(DccCert::class.java)
 		val chLightCertAdapter = moshi.adapter(ChLightCert::class.java)
 


### PR DESCRIPTION
Trim string fields when decoding certificates. This fixes the whitespace issue documented [here](https://github.com/eu-digital-green-certificates/dcc-quality-assurance/blob/main/SpecialCaseHandling.md)