### PR TITLE
Update Github Workflow dependencies

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -29,7 +29,7 @@ jobs:
       - name: Build
         run: ./gradlew build
       - name: Publish Unit Test Results
-        uses: EnricoMi/publish-unit-test-result-action/composite@95a3aff882d4abe2838b187c66477be7fbf3ddb8
+        uses: EnricoMi/publish-unit-test-result-action/composite@7d2b398935a3c7c4eb6332c2d6049e2dad775e1d
         if: always()
         with:
           files: build/test-results/test/*.xml

--- a/.github/workflows/gradle-wrapper-validation.yml
+++ b/.github/workflows/gradle-wrapper-validation.yml
@@ -10,4 +10,4 @@ jobs:
       - uses: actions/checkout@v2
         with:
           submodules: true
-      - uses: gradle/wrapper-validation-action@1ed3d1cbba6f8f077128463ced1769606d17b77b
+      - uses: gradle/wrapper-validation-action@84d7e182ae7c7a37f200c184f64038fb0e62dd7d

--- a/.github/workflows/upload-release.yml
+++ b/.github/workflows/upload-release.yml
@@ -36,7 +36,7 @@ jobs:
             build/reports
       # Release
       - name: Create Github release
-        uses: softprops/action-gh-release@b7e450da2a4b4cb4bfbae528f788167786cfcedf
+        uses: softprops/action-gh-release@8a65c813553f4d05769635eb1b70180d25b9b61b
         with:
           files: |
             build/libs/CovidCertificate-SDK-Kotlin-*.jar


### PR DESCRIPTION
Fixes #52 and #53. Those seem to have a low impact for us, but nevertheless we want to keep our dependencies up-to-date.