### PR TITLE
Add helper methods to pretty print the PersonName

### DIFF
--- a/src/main/java/ch/admin/bag/covidcertificate/sdk/core/models/healthcert/PersonName.kt
+++ b/src/main/java/ch/admin/bag/covidcertificate/sdk/core/models/healthcert/PersonName.kt
@@ -20,4 +20,14 @@ data class PersonName(
 	@Json(name = "fnt") val standardizedFamilyName: String,
 	@Json(name = "gn") val givenName: String?,
 	@Json(name = "gnt") val standardizedGivenName: String?,
-) : Serializable
+) : Serializable {
+
+	fun prettyFamilyName(): String = familyName ?: standardizedFamilyName
+
+	fun prettyGivenName(): String = givenName ?: (standardizedGivenName ?: "")
+
+	fun prettyName(): String = "${prettyFamilyName()} ${prettyGivenName()}"
+
+	// Don't fall back to the givenName if the standardizedGivenName is null, since the givenName can reasonably contain non-standard characters.
+	fun prettyStandardizedName(): String = "${standardizedFamilyName}<<${standardizedGivenName ?: ""}"
+}

--- a/src/test/java/ch/admin/bag/covidcertificate/sdk/core/models/healthcert/PersonNameTest.kt
+++ b/src/test/java/ch/admin/bag/covidcertificate/sdk/core/models/healthcert/PersonNameTest.kt
@@ -1,0 +1,135 @@
+/*
+ * Copyright (c) 2022 Ubique Innovation AG <https://www.ubique.ch>
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ *
+ * SPDX-License-Identifier: MPL-2.0
+ */
+package ch.admin.bag.covidcertificate.sdk.core.models.healthcert
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+
+class PersonNameTest {
+
+	@Test
+	fun testNormal() {
+		val person = PersonName(
+			familyName = "Müller",
+			standardizedFamilyName = "Mueller",
+			givenName = "Jörg",
+			standardizedGivenName = "Joerg",
+		)
+		assertEquals(person.prettyFamilyName(), "Müller")
+		assertEquals(person.prettyGivenName(), "Jörg")
+		assertEquals(person.prettyName(), "Müller Jörg")
+		assertEquals(person.prettyStandardizedName(), "Mueller<<Joerg")
+	}
+
+	// 1 value null
+
+	@Test
+	fun testNullFamilyName() {
+		val person = PersonName(
+			familyName = null,
+			standardizedFamilyName = "Mueller",
+			givenName = "Jörg",
+			standardizedGivenName = "Joerg",
+		)
+		assertEquals(person.prettyFamilyName(), "Mueller")
+		assertEquals(person.prettyGivenName(), "Jörg")
+		assertEquals(person.prettyName(), "Mueller Jörg")
+		assertEquals(person.prettyStandardizedName(), "Mueller<<Joerg")
+	}
+
+	@Test
+	fun testNullGivenName() {
+		val person = PersonName(
+			familyName = "Müller",
+			standardizedFamilyName = "Mueller",
+			givenName = null,
+			standardizedGivenName = "Joerg",
+		)
+		assertEquals(person.prettyFamilyName(), "Müller")
+		assertEquals(person.prettyGivenName(), "Joerg")
+		assertEquals(person.prettyName(), "Müller Joerg")
+		assertEquals(person.prettyStandardizedName(), "Mueller<<Joerg")
+	}
+
+	@Test
+	fun testNullStandardizedGivenName() {
+		val person = PersonName(
+			familyName = "Müller",
+			standardizedFamilyName = "Mueller",
+			givenName = "Jörg",
+			standardizedGivenName = null,
+		)
+		assertEquals(person.prettyFamilyName(), "Müller")
+		assertEquals(person.prettyGivenName(), "Jörg")
+		assertEquals(person.prettyName(), "Müller Jörg")
+		assertEquals(person.prettyStandardizedName(), "Mueller<<")
+	}
+
+	// 2 values null
+
+	@Test
+	fun testNullFamilyNameAndGivenName() {
+		val person = PersonName(
+			familyName = null,
+			standardizedFamilyName = "Mueller",
+			givenName = null,
+			standardizedGivenName = "Joerg",
+		)
+		assertEquals(person.prettyFamilyName(), "Mueller")
+		assertEquals(person.prettyGivenName(), "Joerg")
+		assertEquals(person.prettyName(), "Mueller Joerg")
+		assertEquals(person.prettyStandardizedName(), "Mueller<<Joerg")
+	}
+
+	@Test
+	fun testNullFamilyNameAndStandardizedGivenName() {
+		val person = PersonName(
+			familyName = null,
+			standardizedFamilyName = "Mueller",
+			givenName = "Jörg",
+			standardizedGivenName = null,
+		)
+		assertEquals(person.prettyFamilyName(), "Mueller")
+		assertEquals(person.prettyGivenName(), "Jörg")
+		assertEquals(person.prettyName(), "Mueller Jörg")
+		assertEquals(person.prettyStandardizedName(), "Mueller<<")
+	}
+
+	@Test
+	fun testNullGivenNameAndStandardizedGivenName() {
+		val person = PersonName(
+			familyName = "Müller",
+			standardizedFamilyName = "Mueller",
+			givenName = null,
+			standardizedGivenName = null,
+		)
+		assertEquals(person.prettyFamilyName(), "Müller")
+		assertEquals(person.prettyGivenName(), "")
+		assertEquals(person.prettyName(), "Müller ") // note the trailing space
+		assertEquals(person.prettyStandardizedName(), "Mueller<<")
+	}
+
+	// 3 values null
+
+	@Test
+	fun testAllNull() {
+		val person = PersonName(
+			familyName = null,
+			standardizedFamilyName = "Mueller",
+			givenName = null,
+			standardizedGivenName = null,
+		)
+		assertEquals(person.prettyFamilyName(), "Mueller")
+		assertEquals(person.prettyGivenName(), "")
+		assertEquals(person.prettyName(), "Mueller ") // note the trailing space
+		assertEquals(person.prettyStandardizedName(), "Mueller<<")
+	}
+
+}


### PR DESCRIPTION
This is in preparation to fixing https://github.com/admin-ch/CovidCertificate-App-Android/issues/370.

Since there are a lot of these printing/formatting occurrences in the wallet app, it makes sense to pull them out into helpers. And since they are somewhat tied to the `PersonName` class, I think it makes more sense to have them here in the SDK rather than in the app. Also integrators can reuse them if they are in the SDK.

I decided NOT to strip the trailing white space if the givenName is null (see the comments in the test). The case should be rare enough (at least in Switzerland?), so I don't want to pay the overhead of a trim() function call or introduce more if-else complexity. The trailing whitespace shouldn't hurt in the UI. But feel free to convince me of the opposite :)